### PR TITLE
GROW-142 feature: 자산 관리 시트 요약 컴포넌트 구현

### DIFF
--- a/frontend/src/app/asset-management/layout.tsx
+++ b/frontend/src/app/asset-management/layout.tsx
@@ -4,15 +4,17 @@ import AssetManagementTabBar from "@/widgets/assets-management-tab-bar/ui/AssetM
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
+import useMediaQuery from "@/shared/hooks/useMediaQuery";
 
 const AssetManagement: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
+  const { isMobile } = useMediaQuery();
   const pathname = usePathname();
 
   return (
     <motion.div
-      layout
+      layout={!isMobile}
       className={cn(
         "mx-auto flex w-full flex-1 flex-col gap-4 bg-gray-5 except-mobile:px-5",
         pathname === "/asset-management/sheet" ? "" : "max-w-[1400px]",

--- a/frontend/src/app/asset-management/sheet/page.tsx
+++ b/frontend/src/app/asset-management/sheet/page.tsx
@@ -1,22 +1,29 @@
-import { AssetManagementDraggableTable } from "@/widgets";
+import { AssetManagementDraggableTable, AssetSheetSummary } from "@/widgets";
 import { Suspense } from "react";
 import { cookies } from "next/headers";
 import { ACCESS_TOKEN } from "@/shared/constants/cookie";
 import AssetManagementAccessGuideButton from "@/widgets/asset-management-guest-access-guide-button/ui/AssetManagementAccessGuideButton";
 import { getItemNameList } from "@/entities/assetManagement/apis/getItemNameList";
 import { getBrokerAccountList } from "@/entities/assetManagement/apis/getBrokerAccountList";
+import { getAssetsStock } from "@/widgets/asset-management-draggable-table/api/getAssetsStock";
 
 const Sheet = async () => {
   const accessToken = cookies()?.get(ACCESS_TOKEN)?.value;
   const response = await Promise.all([
     getItemNameList(accessToken ?? null),
     getBrokerAccountList(accessToken ?? null),
+    getAssetsStock(accessToken ?? null),
   ]);
 
-  console.log(response[1]);
-
   return (
-    <div>
+    <div className="flex flex-col gap-6 overflow-x-hidden">
+      <AssetSheetSummary
+        totalAssetAmount={response[2].total_asset_amount}
+        totalDividendAmount={response[2].total_dividend_amount}
+        totalProfitRate={response[2].total_profit_rate}
+        totalInvestAmount={response[2].total_invest_amount}
+        totalProfitAmount={response[2].total_profit_amount}
+      />
       <Suspense fallback={<div>테이블 로딩</div>}>
         <AssetManagementDraggableTable
           accessToken={accessToken ?? null}

--- a/frontend/src/widgets/asset-management-summary-card/ui/AssetManagementMobileSummary.tsx
+++ b/frontend/src/widgets/asset-management-summary-card/ui/AssetManagementMobileSummary.tsx
@@ -1,0 +1,56 @@
+import { IncDecRate } from "@/shared";
+
+interface AssetManagementSummaryCardProps {
+  totalAmount: number;
+  investedAmount: number;
+  profitAmount: number;
+  dividendAmount: number;
+  profitRate: number;
+}
+
+const AssetManagementMobileSummary = ({
+  totalAmount,
+  investedAmount,
+  dividendAmount,
+  profitAmount,
+  profitRate,
+}: AssetManagementSummaryCardProps) => {
+  return (
+    <div className="flex w-full flex-col gap-7 bg-white p-5 except-mobile:hidden">
+      <header className="flex flex-col gap-1">
+        <h3 className="text-heading-2 text-gray-80">나의 총 자산</h3>
+        <h3 className="text-[28px] font-bold leading-[33px] text-gray-100">
+          ₩{totalAmount.toLocaleString("ko-KR")}
+        </h3>
+      </header>
+
+      <div className="flex w-full flex-col gap-2">
+        <div className="flex flex-row items-center justify-between">
+          <span className="text-[14px] font-medium text-gray-80">
+            투자 금액
+          </span>
+          <span className="text-heading-4 text-gray-100">
+            ₩{investedAmount.toLocaleString("ko-KR")}
+          </span>
+        </div>
+        <div className="flex flex-row items-center justify-between">
+          <span className="text-[14px] font-medium text-gray-80">수익금</span>
+          <span className="flex flex-row items-center gap-2">
+            <IncDecRate rate={profitRate} />
+            <span className="text-heading-4 text-gray-100">
+              ₩{profitAmount.toLocaleString("ko-KR")}
+            </span>
+          </span>
+        </div>
+        <div className="flex flex-row items-center justify-between">
+          <span className="text-[14px] font-medium text-gray-80">배당금</span>
+          <span className="text-heading-4 text-gray-100">
+            ₩{dividendAmount.toLocaleString("ko-KR")}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AssetManagementMobileSummary;

--- a/frontend/src/widgets/asset-management-summary-card/ui/AssetManagementSummaryCard.tsx
+++ b/frontend/src/widgets/asset-management-summary-card/ui/AssetManagementSummaryCard.tsx
@@ -1,0 +1,27 @@
+import { IncDecRate } from "@/shared";
+
+interface AssetManagementSummaryCardProps {
+  title: string;
+  value: number;
+  ratio?: number;
+}
+
+const AssetManagementSummaryCard = ({
+  title,
+  value,
+  ratio,
+}: AssetManagementSummaryCardProps) => {
+  return (
+    <div className="flex min-w-[246px] flex-1 flex-col gap-5 rounded-[8px] bg-white p-4">
+      <h3 className="text-heading-4 text-gray-80">{title}</h3>
+      <div className="flex w-full flex-row items-center gap-4">
+        <div className="line-clamp-1 whitespace-pre-wrap break-all text-[24px] font-bold text-gray-100">
+          ₩{value.toLocaleString("ko-KR")}
+        </div>
+        {ratio !== undefined && <IncDecRate rate={ratio} />}
+      </div>
+    </div>
+  );
+};
+
+export default AssetManagementSummaryCard;

--- a/frontend/src/widgets/asset-management-summary-card/ui/AssetSheetSummary.tsx
+++ b/frontend/src/widgets/asset-management-summary-card/ui/AssetSheetSummary.tsx
@@ -1,0 +1,48 @@
+import AssetManagementSummaryCard from "@/widgets/asset-management-summary-card/ui/AssetManagementSummaryCard";
+import AssetManagementMobileSummary from "@/widgets/asset-management-summary-card/ui/AssetManagementMobileSummary";
+
+interface AssetSheetSummaryProps {
+  totalAssetAmount: number;
+  totalInvestAmount: number;
+  totalProfitAmount: number;
+  totalProfitRate: number;
+  totalDividendAmount: number;
+}
+
+const AssetSheetSummary = ({
+  totalAssetAmount,
+  totalInvestAmount,
+  totalDividendAmount,
+  totalProfitAmount,
+  totalProfitRate,
+}: AssetSheetSummaryProps) => {
+  return (
+    <>
+      <div className="flex flex-row gap-4 overflow-x-scroll scrollbar-hide mobile:hidden">
+        <AssetManagementSummaryCard title="총 자산" value={totalAssetAmount} />
+        <AssetManagementSummaryCard
+          title="투자 금액"
+          value={totalInvestAmount}
+        />
+        <AssetManagementSummaryCard
+          title="수익금"
+          value={totalProfitAmount}
+          ratio={totalProfitRate}
+        />
+        <AssetManagementSummaryCard
+          title="배당금"
+          value={totalDividendAmount}
+        />
+      </div>
+      <AssetManagementMobileSummary
+        totalAmount={totalAssetAmount}
+        investedAmount={totalInvestAmount}
+        profitAmount={totalProfitAmount}
+        dividendAmount={totalDividendAmount}
+        profitRate={totalProfitRate}
+      />
+    </>
+  );
+};
+
+export default AssetSheetSummary;

--- a/frontend/src/widgets/footer/ui/Footer.tsx
+++ b/frontend/src/widgets/footer/ui/Footer.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 
 const Footer = () => {
   const pathname = usePathname();
   return (
-    <motion.footer
-      layout
+    <footer
       className={cn(
         "mx-auto flex h-[84px] w-full items-center justify-between bg-gray-5 px-[20px]",
         pathname === "/asset-management/sheet" ? "" : "max-w-[1400px]",
@@ -16,7 +14,7 @@ const Footer = () => {
     >
       <p>Copyrighted © insightout all rights reserved.</p>
       <p>email@gmail.com</p>
-    </motion.footer>
+    </footer>
   );
 };
 

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -5,14 +5,12 @@ import LogoLink from "./LogoLink";
 import Menus from "./Menu";
 import Profile from "./Profile";
 import { cn } from "@/lib/utils";
-import { motion } from "framer-motion";
 
 export default function Header() {
   const pathname = usePathname();
 
   return (
-    <motion.header
-      layout
+    <header
       className={cn(
         "mx-auto flex h-[64px] w-full items-center justify-between px-[20px]",
         pathname === "/asset-management/sheet" ? "" : "max-w-[1400px]",
@@ -29,6 +27,6 @@ export default function Header() {
           <Profile />
         </div>
       </div>
-    </motion.header>
+    </header>
   );
 }

--- a/frontend/src/widgets/index.ts
+++ b/frontend/src/widgets/index.ts
@@ -15,3 +15,4 @@ export { default as Summary } from "./Summary/ui/Summary";
 export { default as HomeGuestAccessGuideButton } from "./HomeGuestAccessGuide/ui/HomeGuestAccessGuideButton";
 export { default as AssetManagementDraggableTable } from "./asset-management-draggable-table/ui/AssetManagementDraggableTable";
 export { default as Footer } from "./footer/ui/Footer";
+export { default as AssetSheetSummary } from "./asset-management-summary-card/ui/AssetSheetSummary";


### PR DESCRIPTION
## 스크린샷
<img width="527" alt="스크린샷 2024-10-24 오후 4 46 52" src="https://github.com/user-attachments/assets/b0bdc9ad-7796-43ea-8f5d-29a8cf6ebfc7">
<img width="832" alt="스크린샷 2024-10-24 오후 4 46 58" src="https://github.com/user-attachments/assets/dee21319-1d5c-4dc6-9e1f-271a660ed2b4">
<img width="528" alt="스크린샷 2024-10-24 오후 4 47 23" src="https://github.com/user-attachments/assets/879f065b-e2e7-4c76-8bfe-1b4ba53c6431">

## 작업 내용
- 자산 관리 시트 요약 컴포넌트 구현
- API 연동
- 레이아웃 수정