### PR TITLE
GROW-161 fix: 자산 시트 추가, 성공 요청 성공시에만 invalidate 진행하도록 수정

### DIFF
--- a/frontend/src/entities/assetManagement/queries/usePatchAssetStock.ts
+++ b/frontend/src/entities/assetManagement/queries/usePatchAssetStock.ts
@@ -21,11 +21,19 @@ export const usePatchAssetStock = () => {
       accessToken: string;
     }) => patchAssetStock(accessToken, body),
 
-    onSuccess: async () => {
+    onSuccess: async (data) => {
       setLastUpdatedAt(new Date());
-      await queryClient.invalidateQueries({
-        queryKey: keyStore.assetStock.getSummary.queryKey,
-      });
+      const response = (await data.json()) as {
+        status_code: number;
+        content: string;
+        field: string;
+      };
+
+      if (String(response).startsWith("2")) {
+        await queryClient.invalidateQueries({
+          queryKey: keyStore.assetStock.getSummary.queryKey,
+        });
+      }
     },
   });
 };


### PR DESCRIPTION
## 작업 내용
- 자산 시트 추가, 수정 리액트 쿼리 훅에 성공시에만 invalidate를 진행하는 분기문 추가