### PR TITLE
GROW-185 fix: 숫자 입력 컴포넌트 클릭시 셀럭터 맨 뒤로 선택되는 기능 수정

### DIFF
--- a/frontend/src/shared/ui/NumberInput.tsx
+++ b/frontend/src/shared/ui/NumberInput.tsx
@@ -112,8 +112,6 @@ const NumberInput = ({
             const prefix = region === "KRW" ? "₩ " : "$ ";
             e.currentTarget.value = prefix;
           }
-          e.currentTarget.selectionStart = e.currentTarget.selectionEnd =
-            e.currentTarget.value.length;
         }}
         onBlur={(e) => {
           setIsFocused(false);


### PR DESCRIPTION
## 작업 내용
- 숫자 입력 컴포넌트 셀렉터 맨 뒤로 모내지 않도록 onClick 이벤트에서 제거