### PR TITLE
refactor(assetManagement): SERVICE_SERVER_URL로 API 베이스 경로 통일

### DIFF
--- a/frontend/src/entities/assetManagement/apis/deleteAssetStockParent.ts
+++ b/frontend/src/entities/assetManagement/apis/deleteAssetStockParent.ts
@@ -1,7 +1,7 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 export const deleteAssetStockParent = async (accessToken: string, id: string) =>
-  fetchWithTimeout(`${getBaseUrl()}/api/asset/v1/assetstock/${id}`, {
+  fetchWithTimeout(`${SERVICE_SERVER_URL}/api/asset/v1/assetstock/${id}`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/src/entities/assetManagement/apis/deleteAssetStockSub.ts
+++ b/frontend/src/entities/assetManagement/apis/deleteAssetStockSub.ts
@@ -1,7 +1,7 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 export const deleteAssetStockSub = async (accessToken: string, id: number) =>
-  fetchWithTimeout(`${getBaseUrl()}/api/asset/v1/${id}`, {
+  fetchWithTimeout(`${SERVICE_SERVER_URL}/api/asset/v1/${id}`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/src/entities/assetManagement/apis/getBrokerAccountList.ts
+++ b/frontend/src/entities/assetManagement/apis/getBrokerAccountList.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 interface GetBrokerAccountListResponse {
   investment_bank_list: string[];
@@ -7,7 +7,12 @@ interface GetBrokerAccountListResponse {
 
 export const getBrokerAccountList = async (accessToken: string | null) => {
   const response = await fetchWithTimeout(
-    `${getBaseUrl()}/api/asset/v1/bank-accounts`,
+    `${SERVICE_SERVER_URL}/api/asset/v1/bank-accounts`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
   );
 
   if (!response.ok) {

--- a/frontend/src/entities/assetManagement/apis/getItemNameList.ts
+++ b/frontend/src/entities/assetManagement/apis/getItemNameList.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 export interface ItemName {
   name_en: string;
@@ -8,7 +8,12 @@ export interface ItemName {
 
 export const getItemNameList = async (accessToken: string | null) => {
   const response = await fetchWithTimeout(
-    `${getBaseUrl()}/api/asset/v1/stocks`,
+    `${SERVICE_SERVER_URL}/api/asset/v1/stocks`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
   );
 
   if (!response.ok) {

--- a/frontend/src/entities/assetManagement/apis/postAssetStock.ts
+++ b/frontend/src/entities/assetManagement/apis/postAssetStock.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 export interface PostAssetStockRequestBody {
   trade_date?: string;
@@ -15,7 +15,7 @@ export const postAssetStock = async (
   accessToken: string,
   body: PostAssetStockRequestBody,
 ) => {
-  return fetchWithTimeout(`${getBaseUrl()}/api/asset/v1/assetstock`, {
+  return fetchWithTimeout(`${SERVICE_SERVER_URL}/api/asset/v1/assetstock`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/src/entities/assetManagement/apis/putAssetField.ts
+++ b/frontend/src/entities/assetManagement/apis/putAssetField.ts
@@ -1,7 +1,7 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 export const putAssetField = async (accessToken: string, newFields: string[]) =>
-  fetchWithTimeout(`${getBaseUrl()}/api/v1/asset-field`, {
+  fetchWithTimeout(`${SERVICE_SERVER_URL}/api/v1/asset-field`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/src/entities/assetManagement/apis/putAssetStock.ts
+++ b/frontend/src/entities/assetManagement/apis/putAssetStock.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 export interface PutAssetStockRequestBody {
   id: number;
@@ -16,7 +16,7 @@ export const putAssetStock = async (
   accessToken: string,
   body: PutAssetStockRequestBody,
 ) => {
-  return fetchWithTimeout(`${getBaseUrl()}/api/asset/v1/assetstock`, {
+  return fetchWithTimeout(`${SERVICE_SERVER_URL}/api/asset/v1/assetstock`, {
     method: "put",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -9,7 +9,6 @@ export {
   RESPONSE_STATUS,
   API_CHART_SUFFIX,
 } from "./constants/api";
-export { default as validateTokenExpiry } from "./utils/validateTokenExpiry";
 export { default as SegmentedButton } from "./ui/SegmentedButton";
 export { default as SegmentedButtonGroup } from "./ui/SegmentedButtonGroup";
 export { default as DonutChart } from "./ui/DonutChart";
@@ -28,7 +27,6 @@ export {
   ArrowButtons,
 } from "./ui/arrow-buttons";
 export { default as PortfolioItem } from "./ui/PortfolioItem";
-export { default as PortfolioCarousel } from "./ui/PortfolioCarousel";
 export { getAccessToken, getRefreshToken } from "./utils/jwt-cookie";
 export { default as FloatingButton } from "./ui/FloatingButton";
 export { default as NoDataMessage } from "./ui/NoDataMessage";
@@ -39,4 +37,3 @@ export { default as Calendar } from "./ui/calendar/calendar";
 export { default as DatePicker } from "./ui/DatePicker";
 export { default as DragAndDropDropdown } from "./ui/DragAndDropDropdown";
 export { default as CheckBox } from "./ui/CheckBox";
-export { getBaseUrl } from "./utils/getBaseUrl";

--- a/frontend/src/shared/utils/getBaseUrl.ts
+++ b/frontend/src/shared/utils/getBaseUrl.ts
@@ -1,5 +1,0 @@
-import { SERVICE_SERVER_URL } from "@/shared";
-
-export function getBaseUrl() {
-  return SERVICE_SERVER_URL;
-}

--- a/frontend/src/widgets/asset-management-draggable-table/api/getAssetsStock.ts
+++ b/frontend/src/widgets/asset-management-draggable-table/api/getAssetsStock.ts
@@ -1,10 +1,10 @@
-import { fetchWithTimeout, getBaseUrl } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 import { AssetManagementResponse } from "@/widgets/asset-management-draggable-table/types/table";
 
 export const getAssetsStock = async (accessToken: string | null) => {
   if (!accessToken) {
     const mockData = await fetchWithTimeout(
-      `${getBaseUrl()}/api/asset/v1/sample/assetstock`,
+      `${SERVICE_SERVER_URL}/api/asset/v1/sample/assetstock`,
     );
 
     if (!mockData.ok) {
@@ -15,7 +15,7 @@ export const getAssetsStock = async (accessToken: string | null) => {
   }
 
   const response = await fetchWithTimeout(
-    `${getBaseUrl()}/api/asset/v1/assetstock`,
+    `${SERVICE_SERVER_URL}/api/asset/v1/assetstock`,
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/frontend/src/widgets/assets-accumulate-trend/api/getAssetSaveTrent.ts
+++ b/frontend/src/widgets/assets-accumulate-trend/api/getAssetSaveTrent.ts
@@ -1,9 +1,9 @@
-import { fetchWithTimeout, getBaseUrl, LineChartData } from "@/shared";
+import { fetchWithTimeout, LineChartData, SERVICE_SERVER_URL } from "@/shared";
 
 export const getAssetSaveTrent = async (accessToken: string | null) => {
-  let url = `${getBaseUrl()}/api/chart/v1/asset-save-trend`;
+  let url = `${SERVICE_SERVER_URL}/api/chart/v1/asset-save-trend`;
   if (!accessToken) {
-    url = `${getBaseUrl()}/api/chart/v1/sample/asset-save-trend`;
+    url = `${SERVICE_SERVER_URL}/api/chart/v1/sample/asset-save-trend`;
   }
 
   const response = await fetchWithTimeout(url, {


### PR DESCRIPTION
- `getBaseUrl` 함수 제거 및 `SERVICE_SERVER_URL` 사용으로 API 경로 일원화
- 관련된 모든 API 호출 코드에서 `getBaseUrl` 대체
- 더 이상 사용되지 않는 `getBaseUrl.ts` 파일 삭제
- 불필요한 유틸 및 컴포넌트(`validateTokenExpiry`, `PortfolioCarousel`) 정리

이 변경은 유지보수성을 높이고 코드 복잡성을 줄이기 위함입니다.