### PR TITLE
refactor(config): 리라이트 설정 제거 및 서비스 URL 통일

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -14,16 +14,7 @@ const nextConfig = {
     };
     return config;
   },
-
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: "http://api.gaemischool.com:8000/api/:path"
-      }
-    ]
-  }
-};
+}
 
 const sentryConfig = withSentryConfig(nextConfig, {
   org: "gaemischool",

--- a/frontend/src/shared/utils/getServiceUrl.ts
+++ b/frontend/src/shared/utils/getServiceUrl.ts
@@ -1,7 +1,3 @@
 export const getServiceUrl = () => {
-  if (typeof window === "undefined") {
-    return "http://api.gaemischool.com:8000";
-  }
-
-  return "/";
+  return "http://api.gaemischool.com:8000";
 };


### PR DESCRIPTION
리라이트 설정을 제거하고 `getServiceUrl` 함수의 반환값을 서버 URL로 통일했습니다. 이로 인해 클라이언트와 서버 환경 간 URL 처리가 간소화되었습니다.