### PR TITLE
feat(api): 서버 URL 동적 처리 및 API 리라이트 추가

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -7,6 +7,14 @@ const __dirname = path.dirname(__filename);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  rewrites: async () => {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "https://api.gaemischool.com:8000/api/:path*",
+      }
+    ]
+  },
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/frontend/src/entities/assetManagement/apis/getAssetsStock.ts
+++ b/frontend/src/entities/assetManagement/apis/getAssetsStock.ts
@@ -1,18 +1,24 @@
 import { AssetManagementResponse } from "@/widgets/asset-management-draggable-table/types/table";
 import { baseAxios } from "@/shared/lib/axios";
+import { getServiceServerUrl } from "@/shared/utils/getServiceServerUrl";
 
 export const getAssetsStock = async (accessToken: string | null) => {
   if (!accessToken) {
-    const mockData = await baseAxios.get("/api/asset/v1/sample/assetstock");
+    const mockData = await baseAxios.get(
+      `${getServiceServerUrl()}/api/asset/v1/sample/assetstock`,
+    );
 
     return (await mockData.data) as AssetManagementResponse;
   }
 
-  const response = await baseAxios.get("/api/asset/v1/assetstock", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
+  const response = await baseAxios.get(
+    `${getServiceServerUrl()}/api/asset/v1/assetstock`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
-  });
+  );
 
   return (await response.data) as AssetManagementResponse;
 };

--- a/frontend/src/shared/utils/getServiceServerUrl.ts
+++ b/frontend/src/shared/utils/getServiceServerUrl.ts
@@ -1,0 +1,9 @@
+import { SERVICE_SERVER_URL } from "@/shared";
+
+export const getServiceServerUrl = () => {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  return SERVICE_SERVER_URL;
+};


### PR DESCRIPTION
- API 호출 시 서버 URL을 동적으로 처리하기 위해 `getServiceServerUrl` 유틸 함수를 새로 추가함.
- Next.js의 rewrites 설정에 외부 API 요청을 위한 리라이트 규칙 추가.
- 기존 코드 내 하드코딩된 URL을 `getServiceServerUrl`로 변경하여 유지보수성을 개선함.