### PR TITLE
fix(config): API URL에서 포트 번호 제거

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -11,7 +11,7 @@ const nextConfig = {
     return [
       {
         source: "/api/:path*",
-        destination: "https://api.gaemischool.com:8000/api/:path*",
+        destination: "https://api.gaemischool.com/api/:path*",
       }
     ]
   },

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -1,3 +1,3 @@
-export const SERVICE_SERVER_URL = "https://api.gaemischool.com:8000";
+export const SERVICE_SERVER_URL = "https://api.gaemischool.com";
 export const RESPONSE_STATUS = { BAD_REQUEST: 400, INTERNAL_SERVER_ERROR: 500 };
 export const API_CHART_SUFFIX = "api/chart/v1/sample";


### PR DESCRIPTION
API 서버에서 포트를 지정하지 않도록 URL을 수정했습니다.

- next.config.mjs의 rewrite destination에서 포트 번호(8000) 제거
- constants 파일의 SERVICE_SERVER_URL에서 포트 번호(8000) 제거