### PR TITLE
feat(config): Vercel 리다이렉트 설정 추가

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://api.gaemischool.com/api/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
Vercel 배포에서 특정 API 요청을 외부 API로 전달하기 위한 rewrite 설정을 추가했습니다. 이를 통해 `/api/:path*` 요청이 `https://api.gaemischool.com/api/:path*`로 전달됩니다.