### PR TITLE
fix(NumberInput): onBlur 시 불필요한 값 업데이트 방지

### DIFF
--- a/frontend/src/shared/ui/NumberInput.tsx
+++ b/frontend/src/shared/ui/NumberInput.tsx
@@ -121,11 +121,13 @@ const NumberInput = ({
             e.currentTarget.value = prefix;
           }
         }}
-        onBlur={(e) => {
+        onBlur={(_e) => {
           setIsFocused(false);
 
           // onBlur에서 부모 컴포넌트에 값 전달
-          onChange?.(localValue);
+          if (localValue !== value) {
+            onChange?.(localValue);
+          }
         }}
       />
     </label>


### PR DESCRIPTION
- `onBlur` 이벤트에서 변경되지 않은 값이 부모 컴포넌트로 전달되는 문제를 수정했습니다.
- 이제 `localValue`가 기존 `value`와 다를 때만 `onChange`가 호출됩니다.