### PR TITLE
refactor(asset-management): delete API URL 및 함수 파라미터 수정

### DIFF
--- a/frontend/src/entities/asset-management/apis/deleteAssetStockParent.ts
+++ b/frontend/src/entities/asset-management/apis/deleteAssetStockParent.ts
@@ -1,10 +1,17 @@
-import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout } from "@/shared";
+import { getServiceServerUrl } from "@/shared/utils/getServiceServerUrl";
 
-export const deleteAssetStockParent = async (accessToken: string, id: string) =>
-  fetchWithTimeout(`${SERVICE_SERVER_URL}/api/asset/v1/assetstock/${id}`, {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
+export const deleteAssetStockParent = async (
+  accessToken: string,
+  code: string,
+) =>
+  fetchWithTimeout(
+    `${getServiceServerUrl()}/api/asset/v1/assetstock/stock/${code}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
-  });
+  );

--- a/frontend/src/entities/asset-management/apis/deleteAssetStockSub.ts
+++ b/frontend/src/entities/asset-management/apis/deleteAssetStockSub.ts
@@ -1,7 +1,8 @@
-import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout } from "@/shared";
+import { getServiceServerUrl } from "@/shared/utils/getServiceServerUrl";
 
 export const deleteAssetStockSub = async (accessToken: string, id: number) =>
-  fetchWithTimeout(`${SERVICE_SERVER_URL}/api/asset/v1/${id}`, {
+  fetchWithTimeout(`${getServiceServerUrl()}/api/asset/v1/assetstock/${id}`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
- `SERVICE_SERVER_URL` 대신 `getServiceServerUrl` 사용으로 URL 동적 설정
- `deleteAssetStockParent` 함수의 ID 파라미터를 코드로 변경
- URL 구조를 변경하여 API 호출 방식 개선