### PR TITLE
feat(asset-management): 서브행 추가시 해당 종목 아코디언 열리는 기능 추가

### DIFF
--- a/frontend/src/features/asset-management/atoms/openedFieldAtom.ts
+++ b/frontend/src/features/asset-management/atoms/openedFieldAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const openedFieldAtom = atom(new Set<string>());

--- a/frontend/src/features/asset-management/index.ts
+++ b/frontend/src/features/asset-management/index.ts
@@ -1,0 +1,1 @@
+export { openedFieldAtom } from "./atoms/openedFieldAtom";

--- a/frontend/src/widgets/asset-management-draggable-table/hooks/useHandleAssetStock.ts
+++ b/frontend/src/widgets/asset-management-draggable-table/hooks/useHandleAssetStock.ts
@@ -21,6 +21,7 @@ import { useDeleteAssetStockParent } from "@/entities/asset-management/queries/u
 import { parseAssetStockKeyToJsonKey } from "@/entities/asset-management/utils/parseAssetStockKeyToJsonKey";
 import { usePutAssetStock } from "@/entities/asset-management/queries/usePutAssetStock";
 import { useClientSubStock } from "@/entities/asset-management/hooks/useClientSubStock";
+import { openedFieldAtom } from "@/features/asset-management";
 
 interface UseHandleAssetStockParams {
   currencySetting: CurrencyType;
@@ -38,7 +39,7 @@ export const useHandleAssetStock = ({
   const { mutate: originCreateAssetStockParent } =
     usePostAssetStockParent(itemNameList);
   const { mutate: putAssetStock } = usePutAssetStock();
-  const { mutate: originPostAssetStockSub } = usePostAssetStockSub();
+  const { mutate: postAssetStockSub } = usePostAssetStockSub();
   const { mutate: deleteAssetStockSub } = useDeleteAssetStockSub();
   const { mutate: deleteAssetStockParent } = useDeleteAssetStockParent();
 
@@ -48,6 +49,7 @@ export const useHandleAssetStock = ({
 
   const setIsOpenLoginModal = useSetAtom(loginModalAtom);
   const setErrorInfo = useSetAtom(cellErrorAtom);
+  const setOpenedFields = useSetAtom(openedFieldAtom);
 
   const queryClient = useQueryClient();
 
@@ -75,13 +77,15 @@ export const useHandleAssetStock = ({
       return;
     }
 
+    setOpenedFields((prev) => new Set(prev.add(stockName)));
+
     const stockCode = itemNameList.find(
       (item) => item.name_kr === stockName,
     )?.code;
 
     if (!stockCode) return;
 
-    originPostAssetStockSub({
+    postAssetStockSub({
       accessToken,
       body: {
         stock_code: stockCode,

--- a/frontend/src/widgets/asset-management-draggable-table/ui/AssetManagementSheet.tsx
+++ b/frontend/src/widgets/asset-management-draggable-table/ui/AssetManagementSheet.tsx
@@ -37,6 +37,7 @@ import { priceInputFields } from "@/widgets/asset-management-draggable-table/con
 import { exchange } from "@/shared/utils/number";
 import { filedDefaultWidth } from "@/widgets/asset-management-draggable-table/constants/fieldWidth";
 import { round } from "es-toolkit";
+import { openedFieldAtom } from "@/features/asset-management";
 
 const NumberFieldType = {
   Amount: "amount",
@@ -112,8 +113,7 @@ const AssetManagementSheet: FC<AssetManagementDraggableTableProps> = ({
   itemNameList,
   accountList,
 }) => {
-  const [openedFields, setOpenedFields] = useState<string[]>([]);
-
+  const [openedFields, setOpenedFields] = useAtom(openedFieldAtom);
   const [currentSorting] = useAtom(currentSortingTypeAtom);
   const [sortingField] = useAtom(sortingFieldAtom);
   const setCellError = useSetAtom(cellErrorAtom);
@@ -162,7 +162,7 @@ const AssetManagementSheet: FC<AssetManagementDraggableTableProps> = ({
 
           return (
             stock.type === ColumnType.Sub &&
-            openedFields.includes(stock.종목명 as unknown as string)
+            openedFields.has(stock.종목명 as unknown as string)
           );
         })
         .map((stock) =>
@@ -322,14 +322,16 @@ const AssetManagementSheet: FC<AssetManagementDraggableTableProps> = ({
                   <AccordionToggleButton
                     onToggle={(open) => {
                       if (open) {
-                        setOpenedFields((prev) => [...prev, value]);
+                        setOpenedFields((prev) => new Set(prev.add(value)));
                       } else {
-                        setOpenedFields((prev) =>
-                          prev.filter((field) => field !== value),
-                        );
+                        setOpenedFields((prev) => {
+                          prev.delete(value);
+
+                          return new Set(prev);
+                        });
                       }
                     }}
-                    value={openedFields.includes(value)}
+                    value={openedFields.has(value)}
                   />
                   <div className="relative flex w-full flex-row items-center justify-between px-2.5 py-[12.5]">
                     <div className="text-body-2 text-gray-90">{value}</div>


### PR DESCRIPTION
- `jotai`를 사용하여 openedFieldAtom 상태 생성 및 적용
- 기존 useState를 jotai atom 기반으로 리팩토링하여 전역 상태 관리로 변경
- openedFields의 관리 방식 변경: 배열 -> Set 객체로 전환해 성능 최적화