### PR TITLE
feat(ui): [#OLF-36] 툴팁 생성 로직 분리 및 재사용성 강화

### DIFF
--- a/frontend/src/shared/ui/Tooltip.tsx
+++ b/frontend/src/shared/ui/Tooltip.tsx
@@ -22,7 +22,7 @@ function TooltipTrigger({ children }: PropsWithChildren) {
 function TooltipContent({ children }: PropsWithChildren) {
   return (
     <TooltipContentOrigin
-      className="flex w-[230px] -translate-y-[6px] translate-x-1 flex-col items-center space-y-1 overflow-visible rounded-[8px] bg-gray-70 p-2.5 text-xs font-normal text-white"
+      className="flex max-w-[230px] -translate-y-[6px] translate-x-1 flex-col items-center space-y-1 overflow-visible rounded-[8px] bg-gray-70 p-2.5 text-xs font-normal text-white"
       sideOffset={5}
       side="top"
     >

--- a/frontend/src/widgets/asset-management-draggable-table/ui/AssetManagementSheetHeader.tsx
+++ b/frontend/src/widgets/asset-management-draggable-table/ui/AssetManagementSheetHeader.tsx
@@ -11,10 +11,56 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { sortingFieldAtom } from "@/widgets/asset-management-draggable-table/atoms/sortingFieldAtom";
 import { currentSortingTypeAtom } from "../atoms/currentSortingTypeAtom";
 import { fieldTypeIsNumber } from "@/widgets/asset-management-draggable-table/utils/fieldTypeIsNumber";
+import { allField } from "@/entities/asset-management/constants/allField";
 
 interface AssetManagementSheetHeaderProps {
   field: string;
 }
+
+type Field = (typeof allField)[number];
+
+const needTooltipFields = ["수익률", "저가", "고가", "시가"] as const;
+
+type TooltipNeedField = (typeof needTooltipFields)[number];
+
+const checkIsTooltipNeed = (field: Field): field is TooltipNeedField => {
+  // @ts-ignore -- included 호환 안됨
+  if (needTooltipFields.includes(field)) {
+    return true;
+  }
+
+  return false;
+};
+
+const getTooltipContent = (field: TooltipNeedField) => {
+  switch (field) {
+    case "수익률":
+      return `주식을 매수한 평균 매입가입니다. 주가의 변동으로 처음 매입했던
+            가격과 다른 가격으로 매수될 경우 평균을 내서 해당 보유 주식의 전체
+            매수 가격을 표기하는 방법이에요.`;
+    case "시가":
+      return `매매일자 기준 가격입니다.`;
+    case "저가":
+      return `매매일자 기준 가격입니다.`;
+    case "고가":
+      return `매매일자 기준 가격입니다.`;
+    default:
+      throw new Error("옳바르지 않은 입력입니다.");
+  }
+};
+
+const getTooltipForHeader = (field: TooltipNeedField) => {
+  return (
+    <Tooltip>
+      <Tooltip.Trigger>
+        <span className="flex h-5 w-5 items-center justify-center rounded-[4px] hover:bg-gray-10">
+          <Image src={"/images/tip.svg"} width={12} height={12} alt="tip" />
+        </span>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{getTooltipContent(field)}</Tooltip.Content>
+    </Tooltip>
+  );
+};
 
 const AssetManagementSheetHeader = ({
   field,
@@ -43,25 +89,8 @@ const AssetManagementSheetHeader = ({
         {essentialFields.includes(field) && (
           <span className="text-green-60">*</span>
         )}
-        {field === "수익률" && (
-          <Tooltip>
-            <Tooltip.Trigger>
-              <span className="flex h-5 w-5 items-center justify-center rounded-[4px] hover:bg-gray-10">
-                <Image
-                  src={"/images/tip.svg"}
-                  width={12}
-                  height={12}
-                  alt="tip"
-                />
-              </span>
-            </Tooltip.Trigger>
-            <Tooltip.Content>
-              주식을 매수한 평균 매입가입니다. 주가의 변동으로 처음 매입했던
-              가격과 다른 가격으로 매수될 경우 평균을 내서 해당 보유 주식의 전체
-              매수 가격을 표기하는 방법이에요.
-            </Tooltip.Content>
-          </Tooltip>
-        )}
+        {checkIsTooltipNeed(field as Field) &&
+          getTooltipForHeader(field as TooltipNeedField)}
       </span>
       <SortingButton
         sorting={sorting}


### PR DESCRIPTION
- 툴팁이 필요한 필드를 검사하는 함수 `checkIsTooltipNeed` 추가
- 필드에 따른 툴팁 내용을 반환하는 `getTooltipContent` 구현
- 헤더에서 툴팁 생성 로직을 분리하여 `getTooltipForHeader`로 재사용 가능하도록 수정
- 기존 툴팁 최대 너비 조정 (`max-w-[230px]` 추가)로 UI 개선