### PR TITLE
refactor(auth): [#OLF-37] 로그아웃 로직 및 유저 초기화 리팩토링

### DIFF
--- a/frontend/src/app/AuthProvider.tsx
+++ b/frontend/src/app/AuthProvider.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { AuthContext, logout as logoutUser, User } from "@/entities";
+import { AuthContext, User } from "@/entities";
 import getUser from "@/entities/user/api/getUser";
 import React, { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
 
 export default function AuthProvider({
   children,
@@ -10,20 +11,21 @@ export default function AuthProvider({
 }) {
   const [user, setUser] = useState<User | null>(null);
 
-  const logout = () => {
-    setUser(null);
-    logoutUser();
-  };
-  const initializeUser = async () => {
+  const { mutate: initializeUser, isPending: isPendingInitializeUser } =
+    useMutation({ mutationFn: () => originInitializeUser() });
+
+  const originInitializeUser = async () => {
     const user = await getUser();
     setUser(user);
   };
+
   useEffect(() => {
     initializeUser();
-  }, []);
+  }, [initializeUser]);
+
   return (
-    <AuthContext.Provider value={{ user, initializeUser, logout }}>
-      {children}
+    <AuthContext.Provider value={{ user, initializeUser }}>
+      {!isPendingInitializeUser && children}
     </AuthContext.Provider>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -100,8 +100,8 @@ export default function RootLayout({
       </Head>
       <body className={`${pretendard.className}`}>
         <JotaiProvider>
-          <AuthProvider>
-            <QueryClientProvider>
+          <QueryClientProvider>
+            <AuthProvider>
               <TooltipProvider>
                 <div className="relative flex min-h-dvh flex-col text-body-1 text-gray-100">
                   <div className="flex flex-1 flex-col">
@@ -113,8 +113,8 @@ export default function RootLayout({
                   <Footer />
                 </div>
               </TooltipProvider>
-            </QueryClientProvider>
-          </AuthProvider>
+            </AuthProvider>
+          </QueryClientProvider>
         </JotaiProvider>
         <div id="drag-overlay" className="absolute left-0 top-0"></div>
       </body>

--- a/frontend/src/entities/user/actions/logout.ts
+++ b/frontend/src/entities/user/actions/logout.ts
@@ -1,11 +1,9 @@
 "use server";
 
 import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/shared/constants/cookie";
-import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 
-const logout = () => {
+const logout = async () => {
   try {
     const cookieStore = cookies();
     cookieStore.delete(ACCESS_TOKEN);
@@ -13,8 +11,5 @@ const logout = () => {
   } catch (error) {
     console.error("로그아웃 중 에러가 발생했습니다.", error);
   }
-
-  revalidatePath("/", "layout");
-  redirect("/");
 };
 export default logout;

--- a/frontend/src/entities/user/contexts/AuthContext.tsx
+++ b/frontend/src/entities/user/contexts/AuthContext.tsx
@@ -4,7 +4,6 @@ import { User } from "../types/user";
 
 interface AuthContextType {
   user: User | null;
-  logout: () => void;
   initializeUser: () => void;
 }
 

--- a/frontend/src/entities/user/model/useUserLogout.ts
+++ b/frontend/src/entities/user/model/useUserLogout.ts
@@ -1,13 +1,19 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import logout from "../actions/logout";
 import { keyStore } from "@/shared/lib/query-keys";
+import { useRouter } from "next/navigation";
 
 const useUserLogout = () => {
   const queryClient = useQueryClient();
+  const router = useRouter();
+
   const { mutate: logoutUser } = useMutation({
     mutationFn: () => logout(),
-    onMutate: () => {
+    onSettled: () => {
       queryClient.setQueryData(keyStore.user.getUser.queryKey, null);
+    },
+    onSuccess: () => {
+      router.refresh();
     },
   });
   return { logoutUser };

--- a/frontend/src/widgets/header/ui/DropdownMenus.tsx
+++ b/frontend/src/widgets/header/ui/DropdownMenus.tsx
@@ -10,10 +10,12 @@ import { loginModalAtom } from "@/features";
 import { useSetAtom } from "jotai";
 import Link from "next/link";
 import React from "react";
+
 export default function DropdownMenus() {
   const { user } = useUser();
   const { logoutUser } = useUserLogout();
   const setIsOpenLoginModal = useSetAtom(loginModalAtom);
+
   return (
     <>
       <DropdownMenuLabel


### PR DESCRIPTION
- 로그아웃 로직에서 불필요한 revalidatePath와 redirect 제거
- `initializeUser`를 react-query 기반으로 변경하여 상태 관리 개선
- `AuthProvider` 및 컨텍스트에서 `logout` 함수 제거
- 로그아웃 성공 시 라우터를 새로고침하도록 수정
- 컴포넌트 계층 구조를 QueryClientProvider -> AuthProvider로 변경