### PR TITLE
feat(asset-management): "매매" 종류가 매도인 경우 "수익금", "수익률" disabled 처리

### DIFF
--- a/frontend/src/entities/asset-management/types/asset-management.d.ts
+++ b/frontend/src/entities/asset-management/types/asset-management.d.ts
@@ -28,6 +28,7 @@ export interface StockAssetSub {
   수익률: number | null;
   수익금: number | null;
   거래가: number | null;
+  매매: "매수" | "매도";
   수량: number;
   종목명: string;
   거래량: number | null;

--- a/frontend/src/widgets/asset-management-draggable-table/ui/AssetManagementSheet.tsx
+++ b/frontend/src/widgets/asset-management-draggable-table/ui/AssetManagementSheet.tsx
@@ -45,6 +45,12 @@ const NumberFieldType = {
   Rate: "ratio",
 } as const;
 
+const isAssetStockSub = (
+  row: StockAssetSubWithType | StockAssetParentWithType,
+): row is StockAssetSubWithType => {
+  return row.type === ColumnType.Sub;
+};
+
 const fieldNumberType = (field: string): "amount" | "price" | "ratio" => {
   if (field === "수량" || field === "거래량") {
     return NumberFieldType.Amount;
@@ -514,6 +520,10 @@ const AssetManagementSheet: FC<AssetManagementDraggableTableProps> = ({
               );
           }
 
+          if (!isAssetStockSub(currentRow)) {
+            throw new Error("이후는 서브 타입임이 보장되어야 합니다.");
+          }
+
           switch (key) {
             case "종목명":
               return (
@@ -645,7 +655,9 @@ const AssetManagementSheet: FC<AssetManagementDraggableTableProps> = ({
                 />
               );
             case "수익률":
-              return (
+              return currentRow.매매 === "매도" ? (
+                <div className="h-full w-full bg-gray-10" />
+              ) : (
                 <NumberInput
                   value={value ?? undefined}
                   placeholder="자동 계산 필드입니다."
@@ -667,7 +679,9 @@ const AssetManagementSheet: FC<AssetManagementDraggableTableProps> = ({
                 />
               );
             case "수익금":
-              return (
+              return currentRow.매매 === "매도" ? (
+                <div className="h-full w-full bg-gray-10" />
+              ) : (
                 <NumberInput
                   value={value}
                   type={fieldNumberType(key)}


### PR DESCRIPTION
- Asset 타입에 "매매" 속성을 추가하여 매수/매도 구분 가능
- 매도 상태일 경우 수익률 및 수익금 필드에 비활성화 UI 적용
- 서브 타입 여부를 확인하는 유틸 함수 `isAssetStockSub` 추가