### PR TITLE
feat(constants): 환경별 서버 URL 분리

### DIFF
--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -1,3 +1,6 @@
-export const SERVICE_SERVER_URL = "https://api.gaemischool.com";
+export const SERVICE_SERVER_URL =
+  process.env.NODE_ENV === "development"
+    ? "https://api.gaemischool.com"
+    : "https://api.ollass.com";
 export const RESPONSE_STATUS = { BAD_REQUEST: 400, INTERNAL_SERVER_ERROR: 500 };
 export const API_CHART_SUFFIX = "api/chart/v1/sample";


### PR DESCRIPTION
- 개발 환경과 운영 환경에 따라 서로 다른 서버 URL을 사용할 수 있도록 수정
- 개발 환경에서는 `api.gaemischool.com`, 운영 환경에서는 `api.ollass.com`을 사용