### PR TITLE
feat(ui): TooltipWithIcon 컴포넌트 추가 및 카드와 헤더에 툴팁 기능 통합

### DIFF
--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -37,3 +37,4 @@ export { default as Calendar } from "./ui/calendar/calendar";
 export { default as DatePicker } from "./ui/DatePicker";
 export { default as DragAndDropDropdown } from "./ui/DragAndDropDropdown";
 export { default as CheckBox } from "./ui/CheckBox";
+export { default as TooltipWithIcon } from "./ui/TooltipWithIcon";

--- a/frontend/src/shared/ui/Card.tsx
+++ b/frontend/src/shared/ui/Card.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { ReactNode } from "react";
 import { cn } from "@/components/ui/utils";
+import { TooltipWithIcon } from "@/shared";
 
 const fontSizesVariants = {
   xl: "text-xl",
@@ -14,6 +17,8 @@ interface CardProps {
   fontSize?: keyof typeof fontSizesVariants; // fontSize를 위한 prop 추가
   width?: string; // 너비를 위한 prop 추가
   height?: string; // 높이를 위한 prop 추가
+  withTooltip?: boolean;
+  tooltipText?: string;
 }
 
 export default function Card({
@@ -22,6 +27,8 @@ export default function Card({
   width,
   height,
   fontSize = "md",
+  withTooltip = false,
+  tooltipText = "",
 }: CardProps) {
   return (
     <div
@@ -30,9 +37,13 @@ export default function Card({
     >
       {title && (
         <h2
-          className={cn("font-bold text-gray-80", fontSizesVariants[fontSize])}
+          className={cn(
+            "flex flex-row items-center gap-1 font-bold text-gray-80",
+            fontSizesVariants[fontSize],
+          )}
         >
-          {title}
+          <span>{title}</span>
+          {withTooltip && <TooltipWithIcon text={tooltipText} />}
         </h2>
       )}
       {children}

--- a/frontend/src/shared/ui/SegmentedButton.tsx
+++ b/frontend/src/shared/ui/SegmentedButton.tsx
@@ -1,7 +1,6 @@
 import { SegmentedButtonProps } from "../types/component-props";
 
 export default function SegmentedButton({
-  numberOfButtons,
   isSelected = false,
   isHover = false,
   onClick,

--- a/frontend/src/shared/ui/TooltipWithIcon.tsx
+++ b/frontend/src/shared/ui/TooltipWithIcon.tsx
@@ -1,0 +1,17 @@
+import Tooltip from "@/shared/ui/Tooltip";
+import Image from "next/image";
+
+const TooltipWithIcon = ({ text }: { text: string }) => {
+  return (
+    <Tooltip>
+      <Tooltip.Trigger>
+        <span className="flex h-5 w-5 items-center justify-center rounded-[4px] hover:bg-gray-10">
+          <Image src={"/images/tip.svg"} width={12} height={12} alt="tip" />
+        </span>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{text}</Tooltip.Content>
+    </Tooltip>
+  );
+};
+
+export default TooltipWithIcon;

--- a/frontend/src/widgets/Summary/ui/SummaryCard.tsx
+++ b/frontend/src/widgets/Summary/ui/SummaryCard.tsx
@@ -9,10 +9,30 @@ interface SummaryCardProps {
   rate?: number;
 }
 
+const titleToolTipMsgMap = {
+  "나의 총 자산": "매수 기준으로 계산됩니다.",
+  "나의 투자 금액": "매수 기준으로 계산됩니다.",
+  수익금:
+    "매수 기준으로만 계산되며 예상 추정치로 실제 수익률과 다를 수 있습니다.",
+};
+
+const checkIsNeedTooltip = (title: string) => {
+  return Object.keys(titleToolTipMsgMap).includes(title);
+};
+
+const getTooltipMsg = (title: string) => {
+  return titleToolTipMsgMap[title] ?? "";
+};
+
 export default function SummaryCard({ title, amount, rate }: SummaryCardProps) {
   return (
     <div className="w-1/4 mobile:w-full mobile:shrink-0">
-      <Card title={title} height="100px">
+      <Card
+        title={title}
+        height="100px"
+        withTooltip={checkIsNeedTooltip(title ?? "")}
+        tooltipText={getTooltipMsg(title ?? "")}
+      >
         <div className="flex items-center">
           {title !== "지난 달 보다" ? (
             <PriceDisplay price={amount} />

--- a/frontend/src/widgets/estimate-dividend/ui/EstimateDividendClient.tsx
+++ b/frontend/src/widgets/estimate-dividend/ui/EstimateDividendClient.tsx
@@ -7,10 +7,10 @@ import {
   NoDataMessage,
   SegmentedButton,
   SegmentedButtonGroup,
+  TooltipWithIcon,
 } from "@/shared";
-import { useState } from "react";
+import React, { useState } from "react";
 import ArrowNavigator from "./ArrowNavigator";
-import React from "react";
 
 export default function EstimateDividendClient({
   estimatedDividendAll,
@@ -28,20 +28,25 @@ export default function EstimateDividendClient({
     <div
       className={`relative ${selectedTab === "모두" ? "h-[390px]" : "h-full"} w-full rounded-xl border border-gray-20 bg-white p-[16px] mobile:rounded-none ${selectedTab === "모두" ? "mobile:h-[500px]" : "h-full min-h-[388px]"} mobile:border-none`}
     >
-      <h2 className="text-heading-2 text-gray-80">예상 배당액</h2>
-      <div className="mt-[16px] flex w-full justify-between except-mobile:absolute except-mobile:right-[16px] except-mobile:top-[12px] except-mobile:mt-0">
-        <div className="w-[176px] shrink-0 mobile:hidden" />
-        <div className="w-full except-mobile:w-[148px]">
-          <SegmentedButtonGroup>
-            <SegmentedButton onClick={() => setSelectedTab("모두")}>
-              모두
-            </SegmentedButton>
-            <SegmentedButton onClick={() => setSelectedTab("종목별")}>
-              종목별
-            </SegmentedButton>
-          </SegmentedButtonGroup>
+      <header className="flex flex-col except-mobile:flex-row except-mobile:items-center">
+        <h2 className="flex flex-row items-center gap-1 text-heading-2 text-gray-80">
+          <span className="text-nowrap">예상 배당액</span>
+          <TooltipWithIcon text="예상 추정치로 실제 배당금과 다를 수 있습니다." />
+        </h2>
+        <div className="mt-[16px] flex w-full justify-between except-mobile:mt-0">
+          <div className="w-[176px] shrink-0 mobile:hidden" />
+          <div className="w-full except-mobile:w-[148px]">
+            <SegmentedButtonGroup>
+              <SegmentedButton onClick={() => setSelectedTab("모두")}>
+                모두
+              </SegmentedButton>
+              <SegmentedButton onClick={() => setSelectedTab("종목별")}>
+                종목별
+              </SegmentedButton>
+            </SegmentedButtonGroup>
+          </div>
         </div>
-      </div>
+      </header>
       {selectedTab === "모두" &&
         estimatedDividendAll[barChartNavItems[currentNavItemIndex]]?.xAxises
           .length !== 0 && (

--- a/frontend/src/widgets/investment-performance-chart/ui/InvestmentPerformanceChartClient.tsx
+++ b/frontend/src/widgets/investment-performance-chart/ui/InvestmentPerformanceChartClient.tsx
@@ -5,6 +5,7 @@ import {
   NoDataMessage,
   SegmentedButton,
   SegmentedButtonGroup,
+  TooltipWithIcon,
 } from "@/shared";
 import { useState } from "react";
 import PercentWithTitle from "./PercentWithTitle";
@@ -27,24 +28,28 @@ export default function InvestmentPerformanceChartClient({
   const currentData = performanceData[currentPerformanceDataKey];
   return (
     <div className="relative h-[388px] w-full rounded-xl border border-gray-20 bg-white p-[16px] mobile:h-[500px] mobile:rounded-none mobile:border-none">
-      <h2 className="text-heading-2 text-gray-80">투자 성과 분석</h2>
-      <div className="mt-[16px] flex w-full justify-between except-mobile:absolute except-mobile:right-[16px] except-mobile:top-[12px] except-mobile:mt-0">
-        <div className="w-[176px] shrink-0 mobile:hidden" />
-        <div className="w-full except-mobile:w-[428px]">
-          <SegmentedButtonGroup>
-            {PERIODS.map((period) => (
-              <SegmentedButton
-                key={period.period}
-                onClick={() =>
-                  setCurrentPerformanceDataKey(period.performanceDataKey)
-                }
-              >
-                {period.period}
-              </SegmentedButton>
-            ))}
-          </SegmentedButtonGroup>
+      <header className="w-full except-mobile:flex except-mobile:flex-row except-mobile:items-center except-mobile:justify-between">
+        <h2 className="flex flex-row items-center gap-1 text-nowrap text-heading-2 text-gray-80">
+          <span>투자 성과 분석</span>
+          <TooltipWithIcon text="예상 추정치로 실제 수익률과 다를 수 있습니다." />
+        </h2>
+        <div className="mt-[16px] flex w-full justify-between except-mobile:mt-0">
+          <div className="w-full except-mobile:ml-auto except-mobile:max-w-[287px]">
+            <SegmentedButtonGroup>
+              {PERIODS.map((period) => (
+                <SegmentedButton
+                  key={period.period}
+                  onClick={() =>
+                    setCurrentPerformanceDataKey(period.performanceDataKey)
+                  }
+                >
+                  {period.period}
+                </SegmentedButton>
+              ))}
+            </SegmentedButtonGroup>
+          </div>
         </div>
-      </div>
+      </header>
       <div className="flex items-center mobile:flex-col except-mobile:justify-between">
         <div
           className={`space-y-[32px] mobile:mt-[24px] mobile:flex mobile:w-full mobile:space-x-[16px] mobile:space-y-0 ${currentData.xAxises.length === 0 && "hidden mobile:hidden"}`}


### PR DESCRIPTION
- TooltipWithIcon 컴포넌트를 생성하여 툴팁 기능 구현
- Card 컴포넌트에 `withTooltip` 및 `tooltipText` props 추가로 툴팁 지원
- SummaryCard 및 주요 헤더에 툴팁 적용하여 정보 제공 강화
- 추정치 및 분석 데이터에 대해 툴팁으로 상세 설명 추가