### PR TITLE
refactor(Auth): 사용자 상태 관리 및 초기화 로직 개선

### DIFF
--- a/frontend/src/app/AuthProvider.tsx
+++ b/frontend/src/app/AuthProvider.tsx
@@ -1,31 +1,20 @@
 "use client";
 import { AuthContext, User } from "@/entities";
-import getUser from "@/entities/user/api/getUser";
-import React, { useEffect, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import React, { PropsWithChildren, useState } from "react";
+
+interface AuthProviderProps extends PropsWithChildren {
+  user: User | null;
+}
 
 export default function AuthProvider({
   children,
-}: {
-  children: React.ReactNode;
-}) {
-  const [user, setUser] = useState<User | null>(null);
-
-  const { mutate: initializeUser, isPending: isPendingInitializeUser } =
-    useMutation({ mutationFn: () => originInitializeUser() });
-
-  const originInitializeUser = async () => {
-    const user = await getUser();
-    setUser(user);
-  };
-
-  useEffect(() => {
-    initializeUser();
-  }, [initializeUser]);
+  user: initialUserState,
+}: AuthProviderProps) {
+  const [user, setUser] = useState<User | null>(initialUserState);
 
   return (
-    <AuthContext.Provider value={{ user, initializeUser }}>
-      {!isPendingInitializeUser && children}
+    <AuthContext.Provider value={{ user, setUser }}>
+      {children}
     </AuthContext.Provider>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import localFont from "next/font/local";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Head from "next/head";
+import { getUser } from "@/entities";
 
 const pretendard = localFont({
   src: "./fonts/PretendardVariable.woff2",
@@ -89,11 +90,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) {
+  const user = await getUser();
+
   return (
     <html lang="ko">
       <Head>
@@ -102,11 +105,11 @@ export default function RootLayout({
       <body className={`${pretendard.className}`}>
         <JotaiProvider>
           <QueryClientProvider>
-            <AuthProvider>
+            <AuthProvider user={user}>
               <TooltipProvider>
                 <div className="relative flex min-h-dvh flex-col text-body-1 text-gray-100">
                   <div className="flex flex-1 flex-col">
-                    <Header />
+                    {user !== undefined && <Header />}
                     {children}
                   </div>
                   <Footer />

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,11 @@
+import { LoaderCircleIcon } from "lucide-react";
+
+const RootLoading = () => {
+  return (
+    <div>
+      <LoaderCircleIcon />
+    </div>
+  );
+};
+
+export default RootLoading;

--- a/frontend/src/entities/user/contexts/AuthContext.tsx
+++ b/frontend/src/entities/user/contexts/AuthContext.tsx
@@ -4,7 +4,7 @@ import { User } from "../types/user";
 
 interface AuthContextType {
   user: User | null;
-  initializeUser: () => void;
+  setUser: (user: User | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(

--- a/frontend/src/widgets/header/ui/DropdownMenus.tsx
+++ b/frontend/src/widgets/header/ui/DropdownMenus.tsx
@@ -4,16 +4,18 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
-import useUser from "@/entities/user/model/useUser";
-import useUserLogout from "@/entities/user/model/useUserLogout";
 import { loginModalAtom } from "@/features";
 import { useSetAtom } from "jotai";
 import Link from "next/link";
 import React from "react";
+import { User } from "@/entities";
 
-export default function DropdownMenus() {
-  const { user } = useUser();
-  const { logoutUser } = useUserLogout();
+interface DropdownMenusProps {
+  user: User | null;
+  logout: () => void;
+}
+
+export default function DropdownMenus({ user, logout }: DropdownMenusProps) {
   const setIsOpenLoginModal = useSetAtom(loginModalAtom);
 
   return (
@@ -56,7 +58,7 @@ export default function DropdownMenus() {
         </div>
       </DropdownMenuLabel>
 
-      {user?.isJoined ? (
+      {user?.isJoined === true && (
         <>
           <DropdownMenuItem className="px-4 py-[9.5px] text-body-3">
             <Link href="/my-page" className="h-full w-full">
@@ -65,13 +67,14 @@ export default function DropdownMenus() {
           </DropdownMenuItem>
           <DropdownMenuSeparator className="my-2" />
           <DropdownMenuItem
-            onClick={() => logoutUser()}
+            onClick={() => logout()}
             className="px-4 py-[9.5px] text-body-3"
           >
             로그아웃
           </DropdownMenuItem>
         </>
-      ) : (
+      )}
+      {user?.isJoined === false && (
         <>
           <DropdownMenuSeparator
             hidden={user?.isJoined ? false : true}

--- a/frontend/src/widgets/header/ui/Profile.tsx
+++ b/frontend/src/widgets/header/ui/Profile.tsx
@@ -5,8 +5,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import DropdownMenus from "./DropdownMenus";
+import { useUser } from "@/entities";
+import useUserLogout from "@/entities/user/model/useUserLogout";
 
 export default function Profile() {
+  const { user } = useUser();
+  const { logoutUser } = useUserLogout();
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -44,7 +49,7 @@ export default function Profile() {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="p-3">
-        <DropdownMenus />
+        <DropdownMenus user={user} logout={logoutUser} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/src/widgets/join-dialog/ui/JoinDialog.tsx
+++ b/frontend/src/widgets/join-dialog/ui/JoinDialog.tsx
@@ -9,7 +9,7 @@ import { deleteCookie } from "@/shared";
 import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/shared/constants/cookie";
 
 export default function JoinDialog() {
-  const { user, initializeUser } = useUser();
+  const { user, setUser } = useUser();
   const [state, setState] = useState<"agreement" | "nickname">("agreement");
   if (!user || (user && user.isJoined)) {
     return null;
@@ -17,8 +17,9 @@ export default function JoinDialog() {
   const handleClose = () => {
     deleteCookie(ACCESS_TOKEN);
     deleteCookie(REFRESH_TOKEN);
-    initializeUser();
+    setUser(null);
   };
+
   return (
     <Dialog open={user && !user.isJoined}>
       {state === "agreement" ? (
@@ -27,10 +28,7 @@ export default function JoinDialog() {
           nextStep={() => setState("nickname")}
         />
       ) : (
-        <NicknameSetup
-          initializeUser={initializeUser}
-          handleClose={handleClose}
-        />
+        <NicknameSetup handleClose={handleClose} />
       )}
     </Dialog>
   );

--- a/frontend/src/widgets/join-dialog/ui/NicknameSetup.tsx
+++ b/frontend/src/widgets/join-dialog/ui/NicknameSetup.tsx
@@ -13,15 +13,16 @@ import updateNickname from "../api/updateNickname";
 import debounce from "lodash.debounce";
 import checkValidateNickname from "../api/checkValidateNickname";
 import { useRouter } from "next/navigation";
+import { getUser, useUser } from "@/entities";
 
 export default function NicknameSetup({
-  initializeUser,
   handleClose,
 }: {
-  initializeUser: () => void;
   handleClose: () => void;
 }) {
   const router = useRouter();
+  const { setUser } = useUser();
+
   const [nickname, setNickname] = useState<string>("");
   const [isUsed, setIsUsed] = useState<boolean>(false);
   const [isOnFocus, setIsOnFocus] = useState<boolean>(false);
@@ -181,8 +182,13 @@ export default function NicknameSetup({
                   return;
                 }
 
-                initializeUser();
-                router.push("/asset-management");
+                const user = await getUser();
+
+                if (!user) {
+                  return;
+                }
+
+                setUser(user);
               }}
             >
               완료하기


### PR DESCRIPTION
- AuthProvider에서 초기 사용자 상태를 props로 전달받도록 변경
- setUser를 AuthContext에서 지원하도록 수정
- Header, DropdownMenu 등 컴포넌트에 사용자 상태와 관련 로직 주입
- 불필요한 initializeUser 제거 및 관련 로직 단순화
- loading 페이지 추가하여 사용자 경험 개선